### PR TITLE
Fix/resourceBundle

### DIFF
--- a/src/main/java/kotori/Redis.java
+++ b/src/main/java/kotori/Redis.java
@@ -3,11 +3,13 @@ package kotori;
 import redis.clients.jedis.JedisPool;
 import redis.clients.jedis.JedisPoolConfig;
 
+import java.util.MissingResourceException;
 import java.util.Optional;
 import java.util.ResourceBundle;
 
 public class Redis {
     private static final Redis redis = new Redis();
+    private final String DEFAULT_HOST_NAME  = "localhost";
     private JedisPool pool = null;
 
     private Redis() {
@@ -19,15 +21,19 @@ public class Redis {
     }
 
     private void setRedis() {
-        pool = new JedisPool(new JedisPoolConfig(), getRedisHostname().orElse("localhost"));
+        pool = new JedisPool(new JedisPoolConfig(), getRedisHostname());
     }
 
     public JedisPool getJedisPool() {
         return pool;
     }
 
-    private Optional<String> getRedisHostname() {
+    private String getRedisHostname() {
         ResourceBundle resource = ResourceBundle.getBundle("dbsettings");
-        return Optional.ofNullable(resource.getString("redis_hostname"));
+        try {
+            return Optional.ofNullable(resource.getString("redis_hostname")).orElse(DEFAULT_HOST_NAME);
+        } catch (MissingResourceException e) {
+            return DEFAULT_HOST_NAME;
+        }
     }
 }


### PR DESCRIPTION
プロパティに省略可能な`redis_hostname`が記述されてない場合、`MissingResourceException`例外が投げられ起動できない問題を修正